### PR TITLE
(Quick)Fix chosen rendering for Angular 1.5

### DIFF
--- a/src/chosen.coffee
+++ b/src/chosen.coffee
@@ -77,7 +77,7 @@ angular.module('localytics.directives').directive 'chosen', ['$timeout', ($timeo
 
       # This is basically taken from angular ngOptions source.  ngModel watches reference, not value,
       # so when values are added or removed from array ngModels, $render won't be fired.
-      if attr.multiple
+      //if attr.multiple
         viewWatch = -> ngModel.$viewValue
         scope.$watch viewWatch, ngModel.$render, true
     # If we're not using ngModel (and therefore also not using ngOptions, which requires ngModel),


### PR DESCRIPTION
The rendering enhancement that was used in this plugin will not work in angular 1.5 since rc1 ( see https://github.com/angular/angular.js/commit/f7eab8d8fe8cadecaee425f0db0c74e48619310c ) - i noticed the multiple select boxes are still working and just enabled their behavior for all the select boxes by removing the if. If you have a better solution, please remove this quickfix!